### PR TITLE
Fix DbUpdateConcurrencyException in DeleteGroupDuplicates method

### DIFF
--- a/src/MyPhotoHelper/Pages/Duplicates.razor
+++ b/src/MyPhotoHelper/Pages/Duplicates.razor
@@ -917,17 +917,8 @@
                         Logger.LogInformation($"Deleted file: {fullPath}");
                     }
                     
-                    // Mark as deleted in database
-                    var dbImage = await dbContext.tbl_images
-                        .FirstOrDefaultAsync(img => img.ImageId == image.ImageId);
-                        
-                    if (dbImage != null)
-                    {
-                        dbImage.IsDeleted = 1;
-                        dbImage.FileExists = 0;
-                        dbImage.DateModified = DateTime.Now;
-                        dbContext.Update(dbImage);
-                    }
+                    // Mark as deleted in database with retry logic for concurrency
+                    await UpdateImageWithRetry(dbContext, image.ImageId);
                     
                     deletedCount++;
                 }
@@ -937,8 +928,6 @@
                     errors++;
                 }
             }
-            
-            await dbContext.SaveChangesAsync();
             Logger.LogInformation($"Deleted {deletedCount} files from duplicate group with {errors} errors");
             
             // Show result if there were errors
@@ -1062,6 +1051,55 @@
             // Always remove from deleting set
             deletingImages.Remove(image.ImageId);
             StateHasChanged();
+        }
+    }
+
+    private async Task UpdateImageWithRetry(MyPhotoHelper.Data.MyPhotoHelperDbContext dbContext, int imageId, int maxRetries = 3)
+    {
+        for (int attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                // Fresh query to get current state of the image record
+                var dbImage = await dbContext.tbl_images
+                    .FirstOrDefaultAsync(img => img.ImageId == imageId);
+                    
+                if (dbImage != null)
+                {
+                    dbImage.IsDeleted = 1;
+                    dbImage.FileExists = 0;
+                    dbImage.DateModified = DateTime.Now;
+                    dbContext.Update(dbImage);
+                    await dbContext.SaveChangesAsync();
+                    return; // Success - exit retry loop
+                }
+                else
+                {
+                    Logger.LogWarning($"Image with ID {imageId} not found in database");
+                    return; // Image doesn't exist, nothing to update
+                }
+            }
+            catch (Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException ex)
+            {
+                Logger.LogWarning($"Concurrency conflict updating image {imageId}, attempt {attempt + 1}/{maxRetries + 1}");
+                
+                if (attempt == maxRetries)
+                {
+                    Logger.LogError(ex, $"Failed to update image {imageId} after {maxRetries + 1} attempts due to concurrency conflicts");
+                    throw; // Re-throw after all retries exhausted
+                }
+                
+                // Clear the change tracker to prevent cached entity conflicts
+                dbContext.ChangeTracker.Clear();
+                
+                // Wait a small amount before retrying
+                await Task.Delay(50 * (attempt + 1)); // Progressive backoff: 50ms, 100ms, 150ms
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, $"Unexpected error updating image {imageId}");
+                throw; // Re-throw non-concurrency exceptions immediately
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes `DbUpdateConcurrencyException` when deleting duplicate photo groups
- Replaces batch database saves with individual save operations per image
- Implements retry logic with progressive backoff for concurrency conflicts
- Maintains proper error handling and logging

## Problem
Issue #21 reported a database concurrency exception in `DeleteGroupDuplicates` method at line 1082 in `Duplicates.razor`. The error occurred because Entity Framework expected to modify 1 row but affected 0 rows, indicating the record was modified by another operation between loading and saving.

## Solution
1. **Individual Save Operations**: Changed from batch `SaveChangesAsync()` to individual saves per image update
2. **Retry Logic**: Added `UpdateImageWithRetry()` method with up to 3 retry attempts
3. **Progressive Backoff**: Implements 50ms, 100ms, 150ms delays between retry attempts  
4. **Change Tracker Clearing**: Clears EF change tracker between retries to prevent cached entity conflicts
5. **Proper Exception Handling**: Distinguishes concurrency exceptions from other errors

## Test plan
- [x] Code builds successfully without errors
- [x] Maintains existing error handling patterns
- [x] Preserves all existing functionality
- [ ] Test concurrent deletion operations to verify fix
- [ ] Verify retry logic works under database contention
- [ ] Confirm logging shows retry attempts when concurrency conflicts occur

🤖 Generated with [Claude Code](https://claude.ai/code)